### PR TITLE
Add nhl_game_id to the NHL R scoreboard

### DIFF
--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -25,6 +25,9 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
   games <- list(data$games)  # Assuming 'data' contains your example JSON structure
 
   scoreboard_df <- lapply(games, function(game) {
+    # NHL Gamecenter URL - https://www.nhl.com/gamecenter/<nhl_game_id>
+    nhl_game_id <- if (!is.null(game$id)) game$id else {print("NHL ID NA for game:"); print(game); NA}
+
     utc_datetime <- if (!is.null(game$startTimeUTC)) ymd_hms(game$startTimeUTC) else {print("UTC DateTime NA for game:"); print(game); NA}
     local_datetime <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
 
@@ -70,6 +73,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     }
 
     data.frame(
+      nhl_game_id,
       local_datetime,
       visiting_team_abbr,
       visiting_team_score,


### PR DESCRIPTION
The ID assigned by the NHL for a particular game is useful for a variety of reasons. Let's add that to our scoreboard for quick reference.

![Screenshot 2023-12-17 at 2 50 48 PM](https://github.com/TheRobBrennan/explore-nhl-edge-api/assets/4030490/b53c4b65-94ce-4b1e-a797-f264bec15945)
