### PR TITLE
Improve the naming and order of columns in the scoreboard data frame

### DIFF
--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -35,7 +35,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     home_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
     home_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
-    visiting_team_abbr <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
+    away <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
     visiting_team_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
     visiting_team_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
 
@@ -75,7 +75,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     data.frame(
       game_id,
       game_start,
-      visiting_team_abbr,
+      away,
       visiting_team_score,
       home,
       home_score,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -31,7 +31,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     utc_datetime <- if (!is.null(game$startTimeUTC)) ymd_hms(game$startTimeUTC) else {print("UTC DateTime NA for game:"); print(game); NA}
     game_start <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
 
-    home_team_abbr <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
+    home <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
     home_team_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
     home_team_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
@@ -77,7 +77,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       game_start,
       visiting_team_abbr,
       visiting_team_score,
-      home_team_abbr,
+      home,
       home_team_score,
       current_period,
       time_remaining,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -77,13 +77,13 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       game_start,
       away,
       away_score,
+      away_sog,
       home,
       home_score,
+      home_sog,
       period,
       time_remaining,
-      period_desc,
-      away_sog,
-      home_sog
+      period_desc
     )
   })
 

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -63,7 +63,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     }
 
     # TODO: We can probably remove this sometime soon once we have the current_period corrected
-    current_period_descriptor <- if (!is.null(game$periodDescriptor.periodType)) game$periodDescriptor.periodType else {print("Game Outcome Last Period Type Descriptor NA for game:"); print(game); NA}
+    period_desc <- if (!is.null(game$periodDescriptor.periodType)) game$periodDescriptor.periodType else {print("Game Outcome Last Period Type Descriptor NA for game:"); print(game); NA}
 
     # TODO: This is correct. DO NOT CHANGE OR DELETE.
     time_remaining <- if (!is.null(game$clock.timeRemaining)) {
@@ -81,7 +81,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       home_score,
       period,
       time_remaining,
-      current_period_descriptor,
+      period_desc,
       away_sog,
       home_sog
     )

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -40,7 +40,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     away_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
 
     # Setting the current period
-    current_period <- if (!is.null(game$periodDescriptor.number)) {
+    period <- if (!is.null(game$periodDescriptor.number)) {
       period <- game$periodDescriptor.number
       if (!is.null(game$clock.inIntermission)) {
         inIntermission <- game$clock.inIntermission
@@ -79,7 +79,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       away_score,
       home,
       home_score,
-      current_period,
+      period,
       time_remaining,
       current_period_descriptor,
       away_sog,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -25,8 +25,8 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
   games <- list(data$games)  # Assuming 'data' contains your example JSON structure
 
   scoreboard_df <- lapply(games, function(game) {
-    # NHL Gamecenter URL - https://www.nhl.com/gamecenter/<nhl_game_id>
-    nhl_game_id <- if (!is.null(game$id)) game$id else {print("NHL ID NA for game:"); print(game); NA}
+    # NHL Gamecenter URL - https://www.nhl.com/gamecenter/<game_id>
+    game_id <- if (!is.null(game$id)) game$id else {print("NHL ID NA for game:"); print(game); NA}
 
     utc_datetime <- if (!is.null(game$startTimeUTC)) ymd_hms(game$startTimeUTC) else {print("UTC DateTime NA for game:"); print(game); NA}
     game_start <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
@@ -73,7 +73,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     }
 
     data.frame(
-      nhl_game_id,
+      game_id,
       game_start,
       visiting_team_abbr,
       visiting_team_score,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -36,7 +36,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     home_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
     away <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
-    visiting_team_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
+    away_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
     visiting_team_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
 
     # Setting the current period
@@ -76,7 +76,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       game_id,
       game_start,
       away,
-      visiting_team_score,
+      away_score,
       home,
       home_score,
       current_period,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -33,7 +33,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
 
     home <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
     home_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
-    home_team_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
+    home_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
     visiting_team_abbr <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
     visiting_team_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
@@ -83,7 +83,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       time_remaining,
       current_period_descriptor,
       visiting_team_sog,
-      home_team_sog
+      home_sog
     )
   })
 

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -37,7 +37,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
 
     away <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
     away_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
-    visiting_team_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
+    away_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
 
     # Setting the current period
     current_period <- if (!is.null(game$periodDescriptor.number)) {
@@ -82,7 +82,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       current_period,
       time_remaining,
       current_period_descriptor,
-      visiting_team_sog,
+      away_sog,
       home_sog
     )
   })

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -32,7 +32,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     game_start <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
 
     home <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
-    home_team_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
+    home_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
     home_team_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
     visiting_team_abbr <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
@@ -78,7 +78,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       visiting_team_abbr,
       visiting_team_score,
       home,
-      home_team_score,
+      home_score,
       current_period,
       time_remaining,
       current_period_descriptor,

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -29,7 +29,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     nhl_game_id <- if (!is.null(game$id)) game$id else {print("NHL ID NA for game:"); print(game); NA}
 
     utc_datetime <- if (!is.null(game$startTimeUTC)) ymd_hms(game$startTimeUTC) else {print("UTC DateTime NA for game:"); print(game); NA}
-    local_datetime <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
+    game_start <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
 
     home_team_abbr <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
     home_team_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
@@ -74,7 +74,7 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
 
     data.frame(
       nhl_game_id,
-      local_datetime,
+      game_start,
       visiting_team_abbr,
       visiting_team_score,
       home_team_abbr,


### PR DESCRIPTION
This PR improves the column naming and organization of the `scoreboard` data frame:

![Screenshot 2023-12-19 at 1 40 10 PM](https://github.com/TheRobBrennan/explore-nhl-edge-api/assets/4030490/50165153-1234-4688-a2da-29a2a378272b)

Prior to this PR, the `scoreboard` data frame looked like:

![Screenshot 2023-12-19 at 1 24 33 PM](https://github.com/TheRobBrennan/explore-nhl-edge-api/assets/4030490/b5cea538-21b6-4e6f-9130-4434b81b5642)
