### PR TITLE
Display team records in the scoreboard data frame

### DIFF
--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -67,7 +67,6 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     # TODO: We can probably remove this sometime soon once we have the current_period corrected
     period_desc <- if (!is.null(game$periodDescriptor.periodType)) game$periodDescriptor.periodType else {print("Game Outcome Last Period Type Descriptor NA for game:"); print(game); NA}
 
-    # TODO: This is correct. DO NOT CHANGE OR DELETE.
     time_remaining <- if (!is.null(game$clock.timeRemaining)) {
       game$clock.timeRemaining
     } else {

--- a/R/scoreboard.R
+++ b/R/scoreboard.R
@@ -32,10 +32,12 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
     game_start <- if (!is.null(game$venueTimezone)) with_tz(utc_datetime, NHL_EDGE_API_TIMEZONE) else {print("Local DateTime NA for game:"); print(game); NA}
 
     home <- if (!is.null(game$homeTeam.abbrev)) game$homeTeam.abbrev else {print("Home Team Abbreviation NA for game:"); print(game); NA}
+    home_record <- if (!is.null(game$homeTeam.record)) game$homeTeam.record else {print("Home Team Record NA for game:"); print(game); NA}
     home_score <- if (!is.null(game$homeTeam.score)) game$homeTeam.score else {print("Home Team Score NA for game:"); print(game); NA}
     home_sog <- if (!is.null(game$homeTeam.sog)) game$homeTeam.sog else {print("Home Team SOG NA for game:"); print(game); NA}
 
     away <- if (!is.null(game$awayTeam.abbrev)) game$awayTeam.abbrev else {print("Visiting Team Abbreviation NA for game:"); print(game); NA}
+    away_record <- if (!is.null(game$awayTeam.record)) game$awayTeam.record else {print("Visiting Team Record NA for game:"); print(game); NA}
     away_score <- if (!is.null(game$awayTeam.score)) game$awayTeam.score else {print("Visiting Team Score NA for game:"); print(game); NA}
     away_sog <- if (!is.null(game$awayTeam.sog)) game$awayTeam.sog else {print("Visiting Team SOG NA for game:"); print(game); NA}
 
@@ -76,9 +78,11 @@ process_nhl_data <- function(source = "api", fileLocation = NULL) {
       game_id,
       game_start,
       away,
+      away_record,
       away_score,
       away_sog,
       home,
+      home_record,
       home_score,
       home_sog,
       period,


### PR DESCRIPTION
This PR introduces a change in the `scoreboard` data frame so that we can see the records of the away and home team  🏒

![Screenshot 2023-12-19 at 3 23 36 PM](https://github.com/TheRobBrennan/explore-nhl-edge-api/assets/4030490/c7140114-4166-4e4f-936f-641f7bbbaad7)
